### PR TITLE
Update version of GoReleaser action to spit out darwin_arm64 targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v2.8.0
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
Fixes https://github.com/linkpoolio/terraform-provider-chainlink/issues/12

This matches the terraform provider scaffolding version: https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/.github/workflows/release.yml#L42

It looks like [this PR ](https://github.com/goreleaser/goreleaser-action/pull/312)made its way to GoReleaser v2.8.0 which should generate the darwin_arm64 target.