### PR TITLE
Generate manifest file from GoReleaser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         ports:
           - 8545:8545
       chainlink:
-        image: smartcontract/chainlink
+        image: smartcontract/chainlink:0.10.15
         env:
           DATABASE_URL: postgres://postgres:5432/postgres?user=postgres&password=password&sslmode=disable
           ETH_URL: ws://ganache:8545

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2.8.0
+        uses: goreleaser/goreleaser-action@v2.8.1
         with:
           version: latest
           args: release --rm-dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,9 @@ archives:
   - format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 signs:
@@ -50,7 +53,10 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
-# If you want to manually examine the release before its live, uncomment this line:
-# draft: true
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+  # If you want to manually examine the release before its live, uncomment this line:
+  # draft: true
 changelog:
   skip: true


### PR DESCRIPTION
This is an attempt to get publishing working correctly. Right now `1.0.14` is not able to be pulled in for me.

The [docs here](https://www.terraform.io/registry/providers/publishing) suggest that a manifest file should exist so I copied this change from their [maintained scaffolding](https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/.goreleaser.yml#L38).